### PR TITLE
Add random quotes to mobile view and fix style inconsistencies

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -30,6 +30,7 @@ import {
   EnvelopeOpenIcon,
 } from "@radix-ui/react-icons";
 import ThemeToggler from "./ThemeToggler";
+import RandomQuotes from "./RandomQuotes";
 
 export const pages = [
   {
@@ -200,6 +201,9 @@ export default function Navigation() {
           <DrawerContent>
             <div className="max-h-[60vh] overflow-auto">
               <nav>
+                <div className="space-y-2 p-3">
+                  <RandomQuotes />
+                </div>
                 {sections.map((section, sectionIndex) => (
                   <section key={sectionIndex} className="space-y-2 p-3">
                     {section.name ? (

--- a/src/components/Profile.jsx
+++ b/src/components/Profile.jsx
@@ -5,7 +5,7 @@ export default function Profile() {
     <div className="flex w-96 items-center gap-3">
       <Avatar>
         <AvatarImage src="https://source.unsplash.com/random" />
-        <AvatarFallback>UJ</AvatarFallback>
+        <AvatarFallback className="bg-primary-foreground">UJ</AvatarFallback>
       </Avatar>
       <div>
         <p className="text-sm font-semibold">Udoh Jeremiah</p>

--- a/src/components/RandomQuotes.jsx
+++ b/src/components/RandomQuotes.jsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { cn } from "@/lib/utils";
+
 import { useState, useEffect } from "react";
 import { quotes } from "@/data/quotes";
 
@@ -73,7 +75,7 @@ export default function RandomQuotes() {
   }, [index]);
 
   return (
-    <blockquote className="w-[60ch] text-pretty text-xs">
+    <blockquote className={cn("w-full text-pretty text-xs", "lg:w-[60ch]")}>
       <p>
         <span>&quot;{quoteText}&quot;</span>
         <span className="whitespace-nowrap">{authorText}</span>


### PR DESCRIPTION
This adds the random quotes component to the mobile view. However it is brought into view by the hamburger menu, which means the typewriter effect is always active (something which not be the best UX experience). Fixes style inconsistencies also.