### PR TITLE
Enable desktop sidebar navigation to be toggled on or off

### DIFF
--- a/src/app/layout.jsx
+++ b/src/app/layout.jsx
@@ -9,6 +9,8 @@ import { GeistMono } from "geist/font/mono";
 import { Toaster } from "@/components/ui/sonner";
 
 // Components
+import { Separator } from "@/components/ui/separator";
+import { TooltipProvider } from "@/components/ui/tooltip";
 import DesktopNav from "@/components/DesktopNav";
 import Footer from "@/components/Footer";
 import Header from "@/components/Header";
@@ -43,14 +45,17 @@ export default function RootLayout({ children }) {
           enableSystem
           disableTransitionOnChange
         >
-          <Header />
-          <div className={cn("flex-1", "lg:flex")}>
-            <DesktopNav />
-            <div className="w-full">
-              <main>{children}</main>
-              <Footer />
+          <TooltipProvider>
+            <Header />
+            <div className={cn("flex-1", "lg:flex")}>
+              <DesktopNav />
+              <div className="w-full">
+                <main>{children}</main>
+                <Separator className="my-4" />
+                <Footer />
+              </div>
             </div>
-          </div>
+          </TooltipProvider>
         </ThemeProvider>
         <Toaster />
       </body>

--- a/src/components/DesktopNav.jsx
+++ b/src/components/DesktopNav.jsx
@@ -1,22 +1,73 @@
 "use client";
 
+// React
+import { useState } from "react";
+
+// Dependencies
+import { ChevronLeftIcon } from "@radix-ui/react-icons";
+import { ChevronRightIcon } from "@radix-ui/react-icons";
+import { DragHandleDots2Icon } from "@radix-ui/react-icons";
+
 // Components
+import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import Navigation from "./Navigation";
 
 // Hooks
 import { useMediaQuery } from "@/hooks/use-media-query";
 
+// Lib
+import { cn } from "@/lib/utils";
+
+const toggleIcons = [DragHandleDots2Icon, ChevronLeftIcon, ChevronRightIcon];
+
 export default function DesktopNav() {
+  const [open, setOpen] = useState(true);
+  const [iconIndex, setIconIndex] = useState(0);
   const isDesktop = useMediaQuery("(min-width: 1024px)");
+  const Icon = toggleIcons[iconIndex];
 
   return (
     <>
       {isDesktop && (
-        <div className="sticky top-14 h-[calc(100vh-3.5rem)] w-72 border-r bg-muted">
-          <ScrollArea className="h-full py-4">
-            <Navigation />
-          </ScrollArea>
+        <div className="flex">
+          <div
+            className={cn(
+              "sticky top-14 h-[calc(100vh-3.5rem)] w-72 border-r bg-muted opacity-100 transition-[opacity_width]",
+              iconIndex && "opacity-50",
+              !open && "invisible w-0 opacity-0",
+            )}
+          >
+            {open && (
+              <ScrollArea className="h-full py-4">
+                <Navigation />
+              </ScrollArea>
+            )}
+          </div>
+          <div className="sticky top-14 flex h-[calc(100vh-3.5rem)] flex-col items-center justify-center">
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  aria-label={open ? "Close sidebar" : "Open sidebar"}
+                  variant="outline"
+                  onClick={() => setOpen((open) => !open)}
+                  onMouseEnter={() => setIconIndex(open ? 1 : 2)}
+                  onMouseLeave={() => setIconIndex(0)}
+                  className="h-6 w-6 rounded-sm rounded-l-none border-l-0 bg-muted p-0"
+                >
+                  <Icon />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="right">
+                <p>{open ? "Close sidebar" : "Open sidebar"}</p>
+              </TooltipContent>
+            </Tooltip>
+          </div>
         </div>
       )}
     </>

--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -5,7 +5,7 @@ export default function Footer() {
   return (
     <footer
       className={cn(
-        "flex items-center justify-center border-t px-4 py-6 text-center",
+        "flex items-center justify-center px-4 py-6 text-center",
         "sm:px-8",
       )}
     >


### PR DESCRIPTION
This enables the desktop sidebar navigation to be toggled into view or off view. This might be useful for users who don't want to always have it on.

PR also fixes other style inconsistencies, making the project cleaner and easier to maintain.