### PR TITLE
Remove unnecessary videos route from website

### DIFF
--- a/src/app/books/page.jsx
+++ b/src/app/books/page.jsx
@@ -34,8 +34,8 @@ export default async function BooksPage() {
             <AccordionTrigger>{category}</AccordionTrigger>
             <AccordionContent
               className={cn(
-                "grid grid-cols-2 gap-x-4 gap-y-8",
-                "md:grid-cols-4",
+                "grid grid-cols-2 place-items-center gap-x-4 gap-y-8",
+                "md:grid-cols-4 md:place-items-start",
               )}
             >
               {items

--- a/src/app/musics/page.jsx
+++ b/src/app/musics/page.jsx
@@ -24,8 +24,8 @@ export default async function MusicsPage() {
       <p>{description}</p>
       <div
         className={cn(
-          "not-prose mt-8 grid grid-cols-2 gap-x-4 gap-y-10",
-          "md:grid-cols-4",
+          "not-prose mt-8 grid grid-cols-2 place-items-center gap-x-4 gap-y-10",
+          "md:grid-cols-4 md:place-items-start",
         )}
       >
         {songs

--- a/src/data/navigation.js
+++ b/src/data/navigation.js
@@ -84,13 +84,6 @@ export const personal = [
     shortcut: "u",
     active: (pathname) => pathname.startsWith("/musics"),
   },
-  {
-    name: "Videos",
-    href: "/videos",
-    icon: VideoIcon,
-    shortcut: "v",
-    active: (pathname) => pathname.startsWith("/videos"),
-  },
 ];
 
 export const resources = [


### PR DESCRIPTION
This removes the `/videos` route from the website, as it is deemed unnecessary (probably for now).