### PR TITLE
Fix: make random quotes animate once on mobile

### DIFF
--- a/src/components/MobileNav.jsx
+++ b/src/components/MobileNav.jsx
@@ -14,6 +14,7 @@ import { cn } from "@/lib/utils";
 
 export default function MobileNav() {
   const [open, setOpen] = useState(false);
+  const [animateCount, setAnimateCount] = useState(0);
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
@@ -32,7 +33,11 @@ export default function MobileNav() {
       </DrawerTrigger>
       <DrawerContent>
         <div className="max-h-[60vh] overflow-auto">
-          <Navigation setMobileNav={setOpen} />
+          <Navigation
+            mobileAnimateCount={animateCount}
+            setMobileAnimateCount={setAnimateCount}
+            setMobileNav={setOpen}
+          />
         </div>
       </DrawerContent>
     </Drawer>

--- a/src/components/MobileNavItems.jsx
+++ b/src/components/MobileNavItems.jsx
@@ -14,11 +14,19 @@ import { sections } from "@/data/navigation";
 // Lib
 import { cn } from "@/lib/utils";
 
-export default function MobileNavItems({ setMobileNav, pathname }) {
+export default function MobileNavItems({
+  pathname,
+  mobileAnimateCount,
+  setMobileAnimateCount,
+  setMobileNav,
+}) {
   return (
     <nav>
       <div className="space-y-2 p-3">
-        <RandomQuotes />
+        <RandomQuotes
+          animateCount={mobileAnimateCount}
+          setAnimateCount={setMobileAnimateCount}
+        />
       </div>
       {sections.map((section, sectionIndex) => (
         <section key={sectionIndex} className="space-y-2 p-3">

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -16,7 +16,11 @@ import { sections } from "@/data/navigation";
 // Hooks
 import { useMediaQuery } from "@/hooks/use-media-query";
 
-export default function Navigation({ setMobileNav }) {
+export default function Navigation({
+  mobileAnimateCount,
+  setMobileAnimateCount,
+  setMobileNav,
+}) {
   const pathname = usePathname();
   const router = useRouter();
   const isDesktop = useMediaQuery("(min-width: 1024px)");
@@ -52,7 +56,12 @@ export default function Navigation({ setMobileNav }) {
       {isDesktop ? (
         <DesktopNavItems pathname={pathname} />
       ) : (
-        <MobileNavItems setMobileNav={setMobileNav} pathname={pathname} />
+        <MobileNavItems
+          pathname={pathname}
+          mobileAnimateCount={mobileAnimateCount}
+          setMobileAnimateCount={setMobileAnimateCount}
+          setMobileNav={setMobileNav}
+        />
       )}
     </>
   );

--- a/src/components/RandomQuotes.jsx
+++ b/src/components/RandomQuotes.jsx
@@ -11,7 +11,11 @@ import { cn } from "@/lib/utils";
 
 const ONE_DAY_IN_MILLISECONDS = 24 * 60 * 60 * 1000;
 
-export default function RandomQuotes() {
+export default function RandomQuotes({
+  animateCount = 0,
+  setAnimateCount = null,
+  animateStop = 1,
+}) {
   const [index, setIndex] = useState(null);
   const [quoteText, setQuoteText] = useState("");
   const [authorText, setAuthorText] = useState("");
@@ -52,6 +56,12 @@ export default function RandomQuotes() {
   }, []);
 
   useEffect(() => {
+    if (animateCount === animateStop) {
+      setQuoteText(quotes[index]?.quote);
+      setAuthorText(" - " + quotes[index]?.author);
+      return;
+    }
+
     let i = 0;
 
     const typingInterval = setInterval(() => {
@@ -71,12 +81,16 @@ export default function RandomQuotes() {
         }
         setAuthorText(" — " + quotes[index]?.author.substring(0, j++));
       }, 50);
+
+      setAnimateCount
+        ? setAnimateCount((prevAnimateCount) => prevAnimateCount + 1)
+        : animateCount++;
     };
 
     return () => {
       clearInterval(typingInterval);
     };
-  }, [index]);
+  }, [index, animateCount, setAnimateCount, animateStop]);
 
   return (
     <blockquote className={cn("w-full text-pretty text-xs", "lg:w-[60ch]")}>

--- a/src/data/quotes.json
+++ b/src/data/quotes.json
@@ -4,6 +4,14 @@
     "quote": "Hello, World!"
   },
   {
+    "author": "Abdelrahman Dwedar",
+    "quote": "Programming is a continues learning journey, software always have new updates, and so shall we update ourselves too."
+  },
+  {
+    "author": "Abhijit Naskar",
+    "quote": "In a world run by algorithms of greed write a code that helps 'n heals."
+  },
+  {
     "author": "Ada Lovelace",
     "quote": "The Analytical Engine weaves algebraic patterns just as the Jacquard loom weaves flowers and leaves."
   },
@@ -37,6 +45,10 @@
   },
   {
     "author": "Andrew Hunt",
+    "quote": "We believe that the major benefits of testing happen when you think about and write the tests, not when you run them."
+  },
+  {
+    "author": "Andrew Hunt",
     "quote": "No one in the brief history of computing has ever written a piece of perfect software. It's unlikely that you'll be the first."
   },
   {
@@ -46,6 +58,14 @@
   {
     "author": "Anonymous",
     "quote": "It's not a bug, it's a feature."
+  },
+  {
+    "author": "Bill Gates",
+    "quote": "Measuring programming progress by lines of code is like measuring aircraft building progress by weight."
+  },
+  {
+    "author": "Bjarne Stroustrup",
+    "quote": "An understanding of every language-technical detail of a language feature or library component is neither necessary nor sufficient for writing good programs."
   },
   {
     "author": "Bjarne Stroustrup",
@@ -148,6 +168,10 @@
     "quote": "To me programming is more than an important practical art. It is also a gigantic undertaking in the foundations of knowledge."
   },
   {
+    "author": "Grady Booch",
+    "quote": "The function of a good software is to make the complex appear to be simple."
+  },
+  {
     "author": "Guido van Rossum",
     "quote": "Python's a drop-in replacement for BASIC in the sense that Optimus Prime is a drop-in replacement for a truck."
   },
@@ -186,6 +210,10 @@
   {
     "author": "Ken Thompson",
     "quote": "One of my most productive days was throwing away 1,000 lines of code."
+  },
+  {
+    "author": "Kent Beck",
+    "quote": "Listening , Testing , Coding , Designing. That's all there is to software. Anyone who tells you different is selling something."
   },
   {
     "author": "Kent Beck",
@@ -249,6 +277,10 @@
   },
   {
     "author": "Paul Graham",
+    "quote": "A programming language is for thinking about programs, not for expressing programs you've already thought of. It should be a pencil, not a pen."
+  },
+  {
+    "author": "Paul Graham",
     "quote": "In programming, the hard part isn't solving problems, but deciding what problems to solve."
   },
   {
@@ -284,6 +316,10 @@
     "quote": "Free software is a matter of liberty, not price. To understand the concept, you should think of 'free' as in 'free speech,' not as in 'free beer.'"
   },
   {
+    "author": "Robert S. Barton",
+    "quote": "System programmers are the high priests of a low cult."
+  },
+  {
     "author": "Robert C. Martin",
     "quote": "Truth can only be found in one place: the code."
   },
@@ -314,6 +350,10 @@
   {
     "author": "Tim Berners-Lee",
     "quote": "The Web does not just connect machines, it connects people."
+  },
+  {
+    "author": "Vladimir Kameñar",
+    "quote": "Programming is another way of thinking."
   },
   {
     "author": "Ward Cunningham",


### PR DESCRIPTION
This makes the `RandomQuotes` component animate once on mobile devices, mimicking the same behaviour (or effect) we have for the desktop navbar, which is possible because its parts of the `RootLayout`, which doesn't change when navigating to different routes.