### PR TITLE
Fix: drawer mobile menu not scrollable on mobile devices

### DIFF
--- a/src/components/MobileNav.jsx
+++ b/src/components/MobileNav.jsx
@@ -32,7 +32,7 @@ export default function MobileNav() {
         </Button>
       </DrawerTrigger>
       <DrawerContent>
-        <div className="max-h-[60vh] overflow-auto">
+        <div className="h-[60vh] overflow-auto">
           <Navigation
             mobileAnimateCount={animateCount}
             setMobileAnimateCount={setAnimateCount}


### PR DESCRIPTION
This possibly fixes the error of the mobile drawer menu that is not scrolling smoothly on some mobile devices or doesn't scroll at all on some.