### PR TITLE
fix: menu slides in and out on page navigation

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -74,7 +74,7 @@ export type Props = Record<string, never>;
   aria-label="Menu"
   aria-hidden="true"
   data-state="closed"
-  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform transform-3d sm:p-8 lg:px-12"
+  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform [data-state=closed]:translate-y-full [data-state=open]:translate-y-0"
 >
   <button
     id="site-nav-close"

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -74,7 +74,7 @@ export type Props = Record<string, never>;
   aria-label="Menu"
   aria-hidden="true"
   data-state="closed"
-  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform [data-state=closed]:translate-y-full [data-state=open]:translate-y-0"
+  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform sm:p-8 lg:px-12 [data-state=closed]:translate-y-full [data-state=open]:translate-y-0"
 >
   <button
     id="site-nav-close"


### PR DESCRIPTION
This fixes the issue of the menu sliding in and out on page navigation without being triggered.