### PR TITLE
fix(navigation.astro): reverts to old style

### DIFF
--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -62,7 +62,7 @@ export type Props = Record<string, never>;
   type="button"
   aria-controls="site-nav"
   aria-expanded="false"
-  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 sm:p-8 lg:px-12"
+  class="text-2xl font-extralight tracking-widest uppercase duration-500 hover:cursor-pointer hover:font-bold sm:text-3xl lg:text-4xl"
 >
   Menu
 </button>

--- a/src/components/Navigation.astro
+++ b/src/components/Navigation.astro
@@ -62,7 +62,7 @@ export type Props = Record<string, never>;
   type="button"
   aria-controls="site-nav"
   aria-expanded="false"
-  class="text-2xl font-extralight tracking-widest uppercase duration-500 hover:cursor-pointer hover:font-bold sm:text-3xl lg:text-4xl"
+  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 sm:p-8 lg:px-12"
 >
   Menu
 </button>
@@ -74,7 +74,7 @@ export type Props = Record<string, never>;
   aria-label="Menu"
   aria-hidden="true"
   data-state="closed"
-  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform sm:p-8 lg:px-12 [data-state=closed]:translate-y-full [data-state=open]:translate-y-0"
+  class="bg-muted fixed inset-0 z-1000 flex h-full w-full flex-col gap-16 overflow-auto px-8 py-4 transition-transform duration-1000 ease-in-out will-change-transform transform-3d sm:p-8 lg:px-12"
 >
   <button
     id="site-nav-close"


### PR DESCRIPTION
This reverts the Navigation.astro component to its previous style, as the issue is in the safari browser